### PR TITLE
fixes case in #include directive

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ foreach(file_name ${example_list})
   add_executable(${base_name} ${file_name})
   add_test(NAME ${base_name} COMMAND ${base_name})
   set_target_properties(${base_name} PROPERTIES FOLDER "example")
+  target_compile_options(${base_name} PUBLIC "-std=c++14")
 endforeach(file_name)
 
 set_target_properties(example84 PROPERTIES

--- a/examples/example91.cpp
+++ b/examples/example91.cpp
@@ -47,7 +47,7 @@ using safe_bool_t = boost::numeric::safe_unsigned_range<
 >;
 
 #define DESKTOP
-#include "motor1.c"
+#include "Motor1.c"
 
 #include <chrono>
 #include <thread>

--- a/include/exception_policies.hpp
+++ b/include/exception_policies.hpp
@@ -25,12 +25,12 @@ namespace numeric {
 // this would emulate the normal C/C++ behavior of permitting overflows
 // and the like.
 struct ignore_exception {
-    static void no_error(const char * message) {}
-    static void uninitialized_error(const char * message) {}
-    static void overflow_error(const char * message) {}
-    static void underflow_error(const char * message) {}
-    static void range_error(const char * message) {}
-    static void domain_error(const char * message) {}
+    static void no_error(const char *) {}
+    static void uninitialized_error(const char *) {}
+    static void overflow_error(const char *) {}
+    static void underflow_error(const char *) {}
+    static void range_error(const char *) {}
+    static void domain_error(const char *) {}
 };
 
 // example - if you want to specify specific behavior for particular exception
@@ -70,7 +70,7 @@ struct no_exception_support {
 // If an exceptional condition is detected at runtime throw the exception.
 // map our exception list to the ones in stdexcept
 struct throw_exception {
-    static void no_error(const char * message) {
+    static void no_error(const char *) {
     }
     static void unintialized_error(const char * message) {
         throw std::invalid_argument(message);

--- a/include/interval.hpp
+++ b/include/interval.hpp
@@ -402,7 +402,7 @@ constexpr bool operator!=(
     const interval<T> & t,
     const interval<U> & u
 ){
-    return ! t == u;
+    return ! (t == u);
 }
 
 template<typename T, typename U>

--- a/include/safe_base_operations.hpp
+++ b/include/safe_base_operations.hpp
@@ -1301,7 +1301,6 @@ typename boost::lazy_enable_if_c<
 constexpr inline operator|(const T & t, const U & u){
     using bwr = bitwise_or_result<T, U>;
     using result_base_type = typename bwr::result_base_type;
-    using exception_policy = typename bwr::exception_policy;
 
     const checked_result<result_base_type> r =
         checked::bitwise_or<result_base_type>(
@@ -1370,7 +1369,6 @@ typename boost::lazy_enable_if_c<
 constexpr inline operator&(const T & t, const U & u){
     using bwr = bitwise_and_result<T, U>;
     using result_base_type = typename bwr::result_base_type;
-    using exception_policy = typename bwr::exception_policy;
 
     const checked_result<result_base_type> r =
         checked::bitwise_and<result_base_type>(
@@ -1407,7 +1405,6 @@ typename boost::lazy_enable_if_c<
 constexpr inline operator^(const T & t, const U & u){
     using bwr = bitwise_or_result<T, U>;
     using result_base_type = typename bwr::result_base_type;
-    using exception_policy = typename bwr::exception_policy;
 
     const checked_result<result_base_type> r =
         checked::bitwise_xor<result_base_type>(t, u);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach(file_name ${test_list})
   add_executable(${base_name} ${file_name})
   add_test(NAME ${base_name} COMMAND ${base_name})
   set_target_properties(${base_name} PROPERTIES FOLDER "tests")
+  target_compile_options(${base_name} PUBLIC "-std=c++14")
 endforeach(file_name)
 
 # end test targets


### PR DESCRIPTION
This enables building under GCC 5.3.1 on case-sensitive file systems such as typical Linux distros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robertramey/safe_numerics/11)
<!-- Reviewable:end -->
