### PR TITLE
Provide top-level index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head>
+  <title>Boost.Name Documentation</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+  <meta http-equiv="refresh" content="0; URL=doc/html/index.html" />
+</head>
+
+<body>
+  Automatic redirection failed, please go to <a href=
+  "doc/index.html">doc/index.html</a>
+</body>
+</html>


### PR DESCRIPTION
This is a Boost requirement, even if the docs are auto-generated. The proposed change redirects to `doc/index.html`, but I am not sure such a file would be generated?