### PR TITLE
Wrong check in operator~

### DIFF
--- a/include/safe_base.hpp
+++ b/include/safe_base.hpp
@@ -260,7 +260,7 @@ public:
     }
     constexpr safe_base operator~() const {
         static_assert(
-            std::numeric_limits<Stored>::is_signed,
+            std::numeric_limits<Stored>::is_unsigned,
             "Bitwise inversion of signed value is an error"
         );
         return ~(m_t);


### PR DESCRIPTION
But also, the error message seams to be confusing. operator~ is well defined for signed integers. Is it just your choice to exclude it from `safe<signed int>`?