### PR TITLE
Possibly incorect definition of checked_result::operaotr<=

### DIFF
--- a/include/checked_result.hpp
+++ b/include/checked_result.hpp
@@ -97,7 +97,7 @@ struct checked_result {
     }
     template<class T>
     constexpr boost::logic::tribool  operator<=(const checked_result<T> & t) const {
-        return ! operator>(t) && ! operator<(t);
+        return ! operator>(t);
     }
     template<class T>
     constexpr boost::logic::tribool operator!=(const checked_result<T> & t) const {


### PR DESCRIPTION
Maybe this was in fact intended, but looks unsymmetrical.

Also, using tribool for relational operators is tricky, as I think, the semantic requirements of strict weak order are not satisfied.