### PR TITLE
Correct all stream operators

### DIFF
--- a/include/checked_result.hpp
+++ b/include/checked_result.hpp
@@ -15,12 +15,15 @@
 // contains operations for doing checked aritmetic on NATIVE
 // C++ types.
 
+#include <istream>
+#include <ostream>
 #include <cassert>
 #include <boost/logic/tribool.hpp>
 
 #include "safe_common.hpp"
 #include "safe_compare.hpp"
 #include "exception.hpp"
+#include "io.hpp"
 
 namespace boost {
 namespace numeric {
@@ -131,75 +134,31 @@ constexpr bool no_exception(const checked_result<R> & cr){
     return cr.no_exception();
 }
 
-} // numeric
-} // boost
-
-#include <ostream>
-#include <istream>
-
-namespace std {
-
-template<typename R>
-std::ostream & operator<<(
-    std::ostream & os,
-    const boost::numeric::checked_result<R> & r
-){
+template<typename CharT, typename Traits, typename R>
+inline std::basic_ostream<CharT, Traits> &
+operator<<(std::basic_ostream<CharT, Traits> & os,
+    const checked_result<R> & r){
     if(r.no_exception())
-        os << static_cast<R>(r);
-    else
-        os << r.m_msg; //static_cast<const char *>(r);
-    return os;
-}
-
-template<>
-std::ostream & operator<<(
-    std::ostream & os,
-    const boost::numeric::checked_result<std::int8_t> & r
-){
-    if(r.no_exception())
-        os << static_cast<std::int16_t>(r);
-    else
-        os << r.m_msg; //static_cast<const char *>(r);
-    return os;
-}
-
-template<>
-std::ostream & operator<<(
-    std::ostream & os,
-    const boost::numeric::checked_result<std::uint8_t> & r
-){
-    if(r.no_exception())
-        os << static_cast<std::uint16_t>(r);
+        os << detail::output(r.m_r);
     else
         os << r.m_msg; //static_cast<const char *>(r);
     return os;
 }
 
 /*
-template<typename R>
-std::istream & operator>>(std::istream & is, const boost::numeric::checked_result<R> & r){
-    is >> r.m_r;
-    return is;
-}
-
-template<typename R>
-std::istream & operator>>(std::istream & is, const boost::numeric::checked_result<std::int8_t> & r){
-    std::int16_t i;
-    is >> i;
-    r.m_r = i;
-    return is;
-}
-
-template<typename R>
-std::istream & operator>>(std::istream & is, const boost::numeric::checked_result<std::uint8_t> & r){
-    std::uint16_t i;
-    is >> i;
-    r.m_r = i;
+template<typename CharT, typename Traits, typename R>
+inline std::basic_istream<CharT, Traits> &
+operator>>(std::basic_istream<CharT, Traits> & is,
+    checked_result<R> & r){
+    detail::input_t<R> value;
+    is >> value;
+    r.m_r = value;
     return is;
 }
 */
 
-} // std
+} // numeric
+} // boost
 
 /////////////////////////////////////////////////////////////////
 // numeric limits for checked<R>

--- a/include/interval.hpp
+++ b/include/interval.hpp
@@ -25,6 +25,7 @@
 #include "utility.hpp" // log
 #include "checked_result.hpp"
 #include "checked.hpp"
+#include "io.hpp"
 
 // from stack overflow
 // http://stackoverflow.com/questions/23815138/implementing-variadic-min-max-functions
@@ -437,32 +438,13 @@ constexpr boost::logic::tribool operator>=(
     return ! (t < u);
 }
 
+template<typename CharT, typename Traits, typename T>
+inline std::basic_ostream<CharT, Traits> &
+operator<<(std::basic_ostream<CharT, Traits> & os, const interval<T> & i){
+    return os << '[' << detail::output(i.l) << ',' << detail::output(i.u) << ']';
+}
+
 } // numeric
 } // boost
-
-#include <iosfwd>
-
-namespace std {
-
-template<typename T>
-std::ostream & operator<<(std::ostream & os, const boost::numeric::interval<T> & i){
-    os << "[" << i.l << "," << i.u << "]";
-    return os;
-}
-
-template<>
-std::ostream & operator<<(std::ostream & os, const boost::numeric::interval<unsigned char> & i){
-    os << "[" << (unsigned)i.l << "," << (unsigned)i.u << "]";
-    return os;
-}
-
-template<>
-std::ostream & operator<<(std::ostream & os, const boost::numeric::interval<signed char> & i){
-    os << "[" << (int)i.l << "," << (int)i.u << "]";
-    return os;
-}
-
-} // std
-
 
 #endif // BOOST_NUMERIC_INTERVAL_HPP

--- a/include/io.hpp
+++ b/include/io.hpp
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef BOOST_NUMERIC_IO_HPP
+#define BOOST_NUMERIC_IO_HPP
+
+namespace boost {
+namespace numeric {
+namespace detail {
+
+template<class T>
+inline const T& output(const T& o)
+{
+    return o;
+}
+
+template<class T>
+inline T output(const T&& o)
+{
+    return o;
+}
+
+inline auto output(char c)
+{
+    return static_cast<int>(c);
+}
+
+inline auto output(signed char c)
+{
+    return static_cast<int>(c);
+}
+
+inline auto output(unsigned char c)
+{
+    return static_cast<int>(c);
+}
+
+template<class T>
+struct input {
+    using type = T;
+};
+
+template<>
+struct input<char> {
+    using type = int;
+};
+
+template<>
+struct input<signed char> {
+    using type = int;
+};
+
+template<>
+struct input<unsigned char> {
+    using type = int;
+};
+
+template<class T>
+using input_t = typename input<T>::type;
+
+} /* detail */
+} /* numeric */
+} /* boost */
+
+#endif

--- a/include/safe_base.hpp
+++ b/include/safe_base.hpp
@@ -104,26 +104,32 @@ constexpr T base_value(
 }
 
 template<
+    class CharT,
+    class Traits,
     class T,
     T Min,
     T Max,
     class P, // promotion policy
     class E  // exception policy
 >
-std::ostream & operator<<(
-    std::ostream & os,
+std::basic_ostream<CharT, Traits> &
+operator<<(
+    std::basic_ostream<CharT, Traits> & os,
     const safe_base<T, Min, Max, P, E> & t
 );
 
 template<
+    class CharT,
+    class Traits,
     class T,
     T Min,
     T Max,
     class P, // promotion policy
     class E  // exception policy
 >
-std::istream & operator>>(
-    std::istream & is,
+std::basic_istream<CharT, Traits> &
+operator>>(
+    std::basic_istream<CharT, Traits> & is,
     safe_base<T, Min, Max, P, E> & t
 );
 
@@ -150,16 +156,6 @@ class safe_base {
     BOOST_CONCEPT_ASSERT((PromotionPolicy<P>));
     BOOST_CONCEPT_ASSERT((ExceptionPolicy<E>));
     Stored m_t;
-
-    friend std::ostream & operator<< <Stored, Min, Max, P, E> (
-        std::ostream & os,
-        const safe_base & t
-    );
-
-    friend std::istream & operator>> <Stored, Min, Max, P, E> (
-        std::istream & is,
-        safe_base & t
-    );
 
     template<
         class StoredX,

--- a/include/safe_base_operations.hpp
+++ b/include/safe_base_operations.hpp
@@ -28,6 +28,7 @@
 #include "safe_compare.hpp"
 #include "checked_result.hpp"
 #include "interval.hpp"
+#include "io.hpp"
 
 namespace boost {
 namespace numeric {
@@ -1426,61 +1427,40 @@ constexpr inline operator^=(T & t, const U & u){
 // stream operators
 
 template<
+    class CharT,
+    class Traits,
     class T,
     T Min,
     T Max,
     class P, // promotion polic
     class E  // exception policy
 >
-std::ostream & operator<<(
-    std::ostream & os,
+inline std::basic_ostream<CharT, Traits> &
+operator<<(std::basic_ostream<CharT, Traits> & os,
     const safe_base<T, Min, Max, P, E> & t
 ){
-    return os << (
-        (std::is_same<T, signed char>::value
-        || std::is_same<T, unsigned char>::value
-        ) ?
-            static_cast<int>(t.m_t)
-        :
-            t.m_t
-    );
-}
-
-namespace {
-    template<class T>
-    struct Temp {
-        T value;
-    }; // primary template
-    template<> struct Temp<signed char> {
-        int value;
-    }; // secondary template
-    template<> struct Temp<unsigned char> {
-        int value;
-    }; // secondary template
-    template<> struct Temp<signed wchar_t> {
-        int value;
-    }; // secondary template
-    template<> struct Temp<unsigned wchar_t> {
-        int value;
-    }; // secondary template
+    return os << detail::output(static_cast<T>(t));
 }
 
 template<
+    class CharT,
+    class Traits,
     class T,
     T Min,
     T Max,
     class P, // promotion polic
     class E  // exception policy
 >
-std::istream & operator>>(
-    std::istream & is,
+inline std::basic_istream<CharT, Traits> &
+operator>>(
+    std::basic_istream<CharT, Traits> & is,
     safe_base<T, Min, Max, P, E> & t
 ){
-    Temp<T> tx;
-    is >> tx.value;
+    detail::input_t<T> value;
+    is >> value;
     if(is.fail())
         E::domain_error("error in file input");
-    t = tx.value;
+    t = value;
     return is;
 }
 

--- a/include/safe_literal.hpp
+++ b/include/safe_literal.hpp
@@ -52,28 +52,15 @@ constexpr T base_value(
     return N;
 }
 
-template<typename T, T N, class P, class E>
-std::ostream & operator<<(
-    std::ostream & os,
-    const safe_literal_impl<T, N, P, E> & t
-){
-    return os << (
-        (std::is_same<T, signed char>::value
-        || std::is_same<T, unsigned char>::value
-        ) ?
-            static_cast<int>(N)
-        :
-            N
-    );
+template<class CharT, class Traits, class T, T N, class P, class E>
+inline std::basic_ostream<CharT, Traits> &
+operator<<(std::basic_ostream<CharT, Traits> & os,
+    const safe_literal_impl<T, N, P, E> & t){
+    return os << detail::output(N);
 }
 
 template<typename T, T N, class P, class E>
 class safe_literal_impl {
-    friend std::ostream & operator<< <T, N, P, E> (
-        std::ostream & os,
-        const safe_literal_impl & t
-    );
-
 public:
 
     ////////////////////////////////////////////////////////////

--- a/test/test_output.cpp
+++ b/test/test_output.cpp
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <sstream>
+#include <cassert>
+#include "../include/safe_integer.hpp"
+
+template<class T>
+inline void test()
+{
+    {
+        std::ostringstream output;
+        output << boost::numeric::safe<T>(1);
+        assert(output.str() == "1");
+    }
+    {
+        std::istringstream input("1");
+        boost::numeric::safe<T> value;
+        input >> value;
+        assert(value == 1);
+    }
+}
+
+int main()
+{
+    test<int>();
+    test<char>();
+    test<signed char>();
+    test<unsigned char>();
+}


### PR DESCRIPTION
* Don't define these inside namespace std.
* Don't use function template specialization. Just regular overloading is sufficient.
* Use generic basic_ostream and basic_istream instead of ostream and istream.
* Move the common functionality into one header and reduce duplication.
* Remove friend declarations: Can be implemented without granting friendship.