### PR TITLE
uncommented an assert

### DIFF
--- a/include/checked_result.hpp
+++ b/include/checked_result.hpp
@@ -64,7 +64,7 @@ struct checked_result {
 
     // accesors
     constexpr operator R() const {
-        //assert(no_exception());
+        assert(no_exception());
         return m_r;
     }
 


### PR DESCRIPTION
Ever since C++14, you can use assertions in constexpr functions. Even if you want to support older constexpr, you can use a C++11-cmpatible trick, as used [here](https://github.com/akrzemi1/Optional/blob/master/optional.hpp#L199-L203).