### PR TITLE
Sort examples with natural order, remove duplicate example11 entry

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,22 +16,21 @@ function( test_compile_fail_example base_name )
 endfunction(test_compile_fail_example)
 
 test_run_pass_example(example1)
-test_run_pass_example(example11)
 test_run_pass_example(example2)
 test_run_pass_example(example3)
 test_run_pass_example(example4)
 test_run_pass_example(example5)
 test_run_pass_example(example6)
 test_run_pass_example(example7)
-# test_run_pass_example(example81) # requires console input
-test_run_pass_example(example82)
-test_run_pass_example(example83)
-# test_run_pass_example(example84) # requires console input
 test_run_pass_example(example10)
 test_run_pass_example(example11)
 test_run_pass_example(example13)
 test_run_pass_example(example15)
 test_run_pass_example(example20)
+# test_run_pass_example(example81) # requires console input
+test_run_pass_example(example82)
+test_run_pass_example(example83)
+# test_run_pass_example(example84) # requires console input
 test_run_pass_example(example92)
 test_run_pass_example(example93)
 


### PR DESCRIPTION
In CMakeLists.txt there was a duplicate entry for example11, which
appears to have been there by mistake and caused following issue to
happen:

```
CMake Error at CMakeLists.txt:72 (add_executable):
  add_executable cannot create target "example11" because another target with
  the same name already exists.  The existing target is an executable created
  in source directory "/…snip…/safe_numerics/example".
  See documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  example/CMakeLists.txt:9 (test_run_pass)
  example/CMakeLists.txt:31 (test_run_pass_example)
```

It doesn't look like examples depend on the order, so I sorted them
naturally too.